### PR TITLE
allow to pass in a custom deserialiser (eg for use with custom registry)

### DIFF
--- a/draughtsman/__init__.py
+++ b/draughtsman/__init__.py
@@ -1,16 +1,24 @@
+from typing import Optional
+
 from refract.json import JSONDeserialiser
 from refract.contrib.apielements import registry, ParseResult
+from refract.registry import Registry
 from draughtsman.drafter import drafter_parse_blueprint_to
 
 
 __all__ = ('parse',)
 
 
-def parse(blueprint: str, generate_source_map: bool = False) -> ParseResult:
+def parse(
+    blueprint: str,
+    generate_source_map: bool = False,
+    deserialiser_cls: JSONDeserialiser = JSONDeserialiser,
+    custom_registry: Optional[Registry] = None
+) -> ParseResult:
     result = drafter_parse_blueprint_to(
         blueprint,
         generate_source_map=generate_source_map
     )
 
-    deserialiser = JSONDeserialiser(registry=registry)
+    deserialiser = deserialiser_cls(registry=custom_registry or registry)
     return deserialiser.deserialise(result)

--- a/tests/test_draughtsman.py
+++ b/tests/test_draughtsman.py
@@ -1,6 +1,7 @@
 import unittest
+from unittest import mock
 import draughtsman
-from refract.contrib.apielements import ParseResult
+from refract.contrib.apielements import ParseResult, registry
 
 
 class DraughtsmanTests(unittest.TestCase):
@@ -19,3 +20,39 @@ class DraughtsmanTests(unittest.TestCase):
             parse_result.api.title.attributes.get('sourceMap').defract,
             [[[0, 8]]]
         )
+
+    def test_custom_deserialiser(self):
+        mock_init = mock.MagicMock(return_value=None)
+        mock_deserialise = mock.MagicMock()
+
+        class CustomDeserialiser:
+            __init__ = mock_init
+            deserialise = mock_deserialise
+
+        draughtsman.parse('# My API', deserialiser_cls=CustomDeserialiser)
+
+        mock_init.assert_called_once_with(
+            registry=registry
+        )
+        self.assertEqual(mock_deserialise.call_count, 1)
+
+    def test_custom_registry(self):
+        mock_init = mock.MagicMock(return_value=None)
+        mock_deserialise = mock.MagicMock()
+
+        class CustomDeserialiser:
+            __init__ = mock_init
+            deserialise = mock_deserialise
+
+        custom_registry = object()
+
+        draughtsman.parse(
+            '# My API',
+            deserialiser_cls=CustomDeserialiser,
+            custom_registry=custom_registry,
+        )
+
+        mock_init.assert_called_once_with(
+            registry=custom_registry
+        )
+        self.assertEqual(mock_deserialise.call_count, 1)


### PR DESCRIPTION
I've developed a custom registry which extends the one from `refract.contrib.apielements` with additional element classes and accessor methods, to make working with the refracted output closer to the AST output (e.g. to be able to do like `parse_result.api.resource_groups[0].resources[0].transitions[0]` instead of lots of anonymous `.children`)

So to be able to use it with `draughtsman` I need to be able to pass in a deserialiser which uses the custom registry.
